### PR TITLE
changes on export entity data func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ run.sh
 deploy_settings.sh
 auto_pull.sh
 secretkey.txt
+train_entity.txt

--- a/src/app/normal/urls.py
+++ b/src/app/normal/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
     url('Count',views.sentence_count,name="Get the number of sentences"),
     url('Get',views.sentence_get,name="Get a untagged sentence"),
 
-    url('Export',views.export,name="Export data")
+    url('Export',views.export,name="Export data"),
 
     url('Del', views.sentence_delete, name="Delete the sentnece which don't have entity")
 

--- a/src/app/normal/views.py
+++ b/src/app/normal/views.py
@@ -304,8 +304,13 @@ class Sen:
             entity_id = i.get('type')
             type_name =queryset2list(EntityType.objects.filter(pk=i.get('type')))[0].get('name')
             count  = tmp_pos[1] - tmp_pos[0] + 1
+            B_label = 1
             while count :
-                res[tmp_pos[0]+count-1] = type_name
+                if B_label and count > 1:
+                    res[tmp_pos[0]+count-1] = 'B-' + type_name
+                    B_label = B_label - 1
+                else:
+                    res[tmp_pos[0]+count-1] = 'I-' + type_name
                 count = count - 1
         return res
 

--- a/src/app/normal/views.py
+++ b/src/app/normal/views.py
@@ -9,6 +9,8 @@ from django.forms.models import model_to_dict
 from app.entity.models import EntityType,EntityTag
 from app.relation.models import RelationType,RelationTag
 
+from pandas import DataFrame
+import pandas as pd
 import json
 import nltk
 import re
@@ -273,6 +275,17 @@ class Sen:
         except e:
             print("No tagged relation in this Sentence")
 
+    @staticmethod
+    def dataframe_initialize():
+        '''
+        初始化DataFrame
+        :return: 初始化好的dataframe，具有有顺序的3列id/word/type
+        '''
+        tmp = pd.DataFrame(columns={'id','word','type'})
+        tmp['id'] = tmp['id'].apply(pd.to_numeric)
+        tmp = tmp[['id','word','type']]
+        return tmp
+
     def output_entity_training_data(self, sen, sen_id):
         '''
         生成输出需要的三列各自的数据
@@ -364,13 +377,10 @@ class Sen:
         :return: None
         '''
         if referer == 'entity':
-            fo = open("filepath\\train_entity.txt", "a+")
-            entity_data = data
-            for j in entity_data:
-                for i in j:
-                     fo.write(str(i.get('id'))+' '+str(i.get('word'))+' '+str(i.get('type'))+'\n')
-                fo.write('\n')
-            fo.close()
+            df = self.dataframe_initialize()
+            df = df.append(data[0],ignore_index=True)
+            print(df)
+            df.to_csv("filepath\\train_entity.csv")
         elif referer == 'relation':
             fo = open("filepath\\rain_relation.json", "a+")
             relation_data = data


### PR DESCRIPTION
conll003的标准格式是四列 word/part-of-speech tag/chunked tag/entity label
但是第二列跟第三列需要根据英语语法进行打标
part-of-speech tag参考此论文：[A Universal Part-of-Speech Tagset](http://www.lrec-conf.org/proceedings/lrec2012/pdf/274_Paper.pdf)
chunked tag参考此论文：[Introduction to the CoNLL 2000 Shared Task:Chunking](https://www.clips.uantwerpen.be/conll2000/pdf/12732tjo.pdf)
所以最终选用simpletansformers中要求的两种格式的另一种 pandas DataFrame with 3 columns:
If a DataFrame is given, each sentence should be split into words, with each word assigned a tag, and with all words from the same sentence given the same sentence_id.
简单讲，3列，一列id，一列词，一列tag
其中tag改善过了，在多个词组成的实体中，第一个词的tag为B-XXX，xxx为实体类型，之后的词tag为I-XXX；而只有一个词组成的实体其tag为I-XXX。
最终输出为csv，训练时pd一提取就行了